### PR TITLE
docs: reach: rs2: connecting-to-the-internet.md: add translation

### DIFF
--- a/docs/reach/rs2/connecting-to-the-internet.md
+++ b/docs/reach/rs2/connecting-to-the-internet.md
@@ -1,11 +1,11 @@
 # Connecting Reach to the Internet
 
-Connect Reach to the Internet to update ReachView to the latest version or to get the corrections from your NTRIP service.
+Conecte o Reach a internet para atualizar o ReachView para a última versão ou para receber correções de um serviço NTRIP.
 
-??? note "Connecting Reach to the Internet via a built-in cellular modem"
+??? note "Conectando o Reach a Internet via modem de celular embutido"
 	##Video guide
 
-	The video below covers the process of SIM card setup.
+	O vídeo abaixo apresenta o processo utilizando um cartão SIM.
 
 	<center>
 
@@ -13,19 +13,19 @@ Connect Reach to the Internet to update ReachView to the latest version or to ge
 
 	</center>
 
-	## Text guide
+	## Guia de texto
 
-	### SIM card setup
+	### Configuração usando cartão SIM
 
 	!!! note ""
-		Make sure you have a nano-SIM card. You can cut your SIM сard to the format.
+		Tenha um cartão SIM nano. Você pode cortar seu cartão sim no formato nano.
 
-	* Find the SIM card slot under the black sealing
+	* O compartimento para cartão SIM está embaixo da borracha de proteção
 
 	!!! danger ""
-		To prevent slot damage, please use it with care.
+		Para previnir danos ao compartimento, use-o com cuidado.
 
-	* Slide the metallic cover to the right to unlock the slot
+	* Empurre a proteção de metal para destravar o compartimento
 
 	<div style="text-align: center;"><img src="../img/reachrs2/connecting-to-the-internet/1-sim-card.png" style="width: 200px;"></div>
 
@@ -41,150 +41,149 @@ Connect Reach to the Internet to update ReachView to the latest version or to ge
 
 	<div style="text-align: center;"><img src="../img/reachrs2/connecting-to-the-internet/4-sim-card.png" style="width: 200px;"></div>
 
-	### Configuring Mobile Data
+	### Configurando Dados Móveis
 
-	* Power up your receiver and connect to it via ReachView app on your device
+	* Ligue o seu receptor e conecte-se a ele via app ReachView no seu dispositivo
 
-	??? note "Connecting to Reach with iOS/Android device"
+	??? note "Conectando ao Reach via dispositivo iOS/Android"
 
-		1. Get the app from [Google Play](https://play.google.com/store/apps/details?id=com.reachview) or [Apple Store](https://itunes.apple.com/us/app/reachview/id1295196887?mt=8)
-		2. Go to Wi-Fi settings on your device
-		3. Connect to Reach hotspot. It appears as **reach:XX:XX**
-		4. Enter password **emlidreach**
-		5. Launch ReachView app
-		6. Choose Reach from the list
+		1. Baixe o aplicativo no [Google Play](https://play.google.com/store/apps/details?id=com.reachview) ou [Apple Store](https://itunes.apple.com/us/app/reachview/id1295196887?mt=8)
+		2. Vá para as configurações de Wi-Fi no seu dispositivo
+		3. Conecte-se ao ponto de acesso do Reach. Aparecerá como **reach:XX:XX**
+		4. Digite a senha **emlidreach**
+		5. Abra o aplicativo ReachView
+		6. Escolha o Reach na lista
 
-	??? note "Connecting via a web browser from any device"
+	??? note "Conectando-se através de um navegador da web em qualquer dispositivo"
 
-		1. Go to Wi-Fi settings on your device
-		2. Connect to Reach hotspot. It appears as **reach:XX:XX**
-		3. Enter password **emlidreach**
-		4. Launch a web browser (we recommend using Chrome or Mozilla)
-		5. Go to 192.168.42.1
+		1. Vá para as configurações de Wi-Fi no seu dispositivo
+		2. Conecte-se ao ponto de acesso do Reach. Aparecerá como **reach:XX:XX**
+		3. Digite a senha **emlidreach**
+		4. Abra um navegador da web (recomendamos usar o Chrome ou Mozilla)
+		5. Digite o seguinte IP 192.168.42.1
 
-	* Wait until Reach finishes loading your SIM сard
+	* Espere até que o Reach termine de ler o cartão SIM
 
 	!!! note ""
-		If the SIM сard requires a PIN code, the app will ask you to type it into the pop-up field. If you don't know your PIN code, contact your cellular service provider for this information.
+		Se o cartão SIM necessitar de um códico PIN, o aplicativo pedirá para inserir em um pop-up. Se você não sabe o seu código PIN, contate o o provedor de serviço para conseguir esta informação.
 
-	You will see the network bars indicating a connected SIM сard. 
+	Você verá barras de rede indicando um cartão SIM conectando.
 
-	* Go to [Mobile data tab](reachview/mobile-data.md) and enable cellular network
+	* Vá na [aba Mobile data](reachview/mobile-data.md) e habilite a rede celular
 
 	<div style="text-align: center;"><img src="../img/reachrs2/connecting-to-the-internet/mobile-data.png" style="width: 800px;"></div>
 
-	If everything is correct, you will see the network bars and the connection type next to the battery icon showing Mobile data is turned on.
+	Se tudo estiver correto, você verá as barras de rede e o tipo de conexão próximo ao ícone de bateria mostrando que os Dados Móveis estão ligados.
 
-??? note "Connecting Reach to the Internet over Wi-Fi"
-	## Connecting to ReachView
+??? note "Conectando o Reach a Internet via Wi-FI"
+	## Conectando ao ReachView
+	
+	??? note "Conectando ao Reach via dispositivo iOS/Android"
 
-	??? note "Connecting to Reach with iOS/Android device"
+		1. Baixe o aplicativo no [Google Play](https://play.google.com/store/apps/details?id=com.reachview) ou [Apple Store](https://itunes.apple.com/us/app/reachview/id1295196887?mt=8)
+		2. Vá para as configurações de Wi-Fi no seu dispositivo
+		3. Conecte-se ao ponto de acesso do Reach. Aparecerá como **reach:XX:XX**
+		4. Digite a senha **emlidreach**
+		5. Abra o aplicativo ReachView
+		6. Escolha o Reach na lista
 
-		1. Get the app from [Google Play](https://play.google.com/store/apps/details?id=com.reachview) or [Apple Store](https://itunes.apple.com/us/app/reachview/id1295196887?mt=8)
-		2. Go to Wi-Fi settings on your device
-		3. Connect to Reach hotspot. It appears as **reach:XX:XX**
-		4. Enter password **emlidreach**
-		5. Launch ReachView app
-		6. Choose Reach from the list
+	??? note "Conectando-se através de um navegador da web em qualquer dispositivo"
 
-	??? note "Connecting via a web browser from any device"
+		1. Vá para as configurações de Wi-Fi no seu dispositivo
+		2. Conecte-se ao ponto de acesso do Reach. Aparecerá como **reach:XX:XX**
+		3. Digite a senha **emlidreach**
+		4. Abra um navegador da web (recomendamos usar o Chrome ou Mozilla)
+		5. Digite o seguinte IP 192.168.42.1
 
-		1. Go to Wi-Fi settings on your device
-		2. Connect to Reach hotspot. It appears as **reach:XX:XX**
-		3. Enter password **emlidreach**
-		4. Launch a web browser (we recommend using Chrome or Mozilla)
-		5. Go to 192.168.42.1
+## Conectando-se ao Wi-Fi
 
+* Vá para guia Wi-Fi
 
-	## Connecting to Wi-Fi
-
-	* Go to the Wi-Fi tab
-
-	* Choose Wi-Fi network
-		
-		* Choose the available one if it’s visible
-		
-		* If you can’t see your mobile hotspot, press *Connect to a hidden network*
+* Escolha a rede Wi-Fi
+	
+	* Escolha a sua rede se estiver visível
+	
+	* Se você não conseguir ver a sua rede móvel, pressione **"Connect to a hidden network"** (Conectar a uma rede oculta)
 
 	<p style="text-align:center" ><img src="../img/reachrs2/connecting-to-the-internet/hidden-network.gif" style="width: 800px;" /></p>
 
-	* Fill in the connection form
-		
-		<details close>
-		<summary> **Steps for Wi-Fi network** </summary>
+* Preencha os campos para a conexão
+	
+	<details close>
+	<summary> **Passos para conectar a rede Wi-Fi** </summary>
 
-		For Wi-Fi network fill in a password
+	Preencha o campo com a senha da rede Wi-Fi
 
-		</details>
-
-
-		<details close>
-		<summary> **Steps for mobile hotspot** </summary>
-
-		For mobile hotspot fill in Network name. Choose Security type and add a password if you have it.
-
-		</details>
+	</details>
 
 
-		!!! danger "Double check the password!"
-			You can unmask the password by clicking on an eye symbol at the end of a password field.
+	<details close>
+	<summary> **Passos para conectar ao ponto de acesso por dispositivos móveis** </summary>
+
+	Para adicionar o ponto de acesso de uma rede móvel, digite o "Network name" (nome), "Security" (tipo de senha) e "Password" (senha) da sua rede Wi-Fi
+
+	</details>
+
+
+	!!! danger "Verifique a senha!"
+		Você pode exibir a senha clicando no símbolo de um olho no final do campo de inserir a senha.
 
 	<p style="text-align:center" ><img src="../img/reachrs2/connecting-to-the-internet/new-connection.gif" style="width: 800px;" /></p>
 
-	* Press the *Connect* button. Network LED should start blinking blue on Reach
+* Pressione o botão **"Connect"** (Conectar). O LED azul deve começar a piscar no Reach
 
 		<p style="text-align:center" ><img src="../img/reachrs2/connecting-to-the-internet/network-scan.gif" style="width: 200px;" /></p>
 
 
-	## Connecting process
+## Processo de conexão
 
-	??? note "Steps for Wi-Fi network"
+??? note "Passos para conectar a rede Wi-Fi"
 
-		If you connecting to Wi-Fi wait until the Network LED stays solid blue.
+	Se você se conectar a rede Wi-Fi, espere até que o LED de rede fique azul.
+	
+
+??? note "Passos para conectar ao ponto de acesso por dispositivos móveis"
+
+	Se você se conectar ao ponto de acesso móvel, siga as etapas a seguir:
+
+	* Ative o ponto de acesso Wi-Fi no seu dispositivo móvel
+	* Verifique se tem o mesmo nome e senha que você preencheu na etapa anterior
+	* Agora reinicie o dispositivo pressionando o botão **Power**
+	* O Reach deve se conectar ao seu ponto de acesso durante a próxima inicialização
 
 
-	??? note "Steps for mobile hotspot"
-
-		If you connecting to mobile hotspot do the following steps:
-
-		* Enable Wi-Fi hotspot on your mobile device
-		* Check that it has the same name and password as you filled in the previous step
-		* Now reboot the device with the **Power** button
-		* Reach should connect to your hotspot during the next boot
-
-
-	* If the connection is successful, you will see the Network LED stays solid blue
+* Se a conexão for bem sucedida, o LED de rede ficará azul
 
 		<p style="text-align:center" ><img src="../img/reachrs2/connecting-to-the-internet/client-mode.png" style="width: 200px;" /></p>
 
-	* If the connection fails, you will see the Network LED stays solid white
+* Se a conexão falhar, o LED de rede ficará branco
 
 		<p style="text-align:center" ><img src="../img/reachrs2/connecting-to-the-internet/hotspot.png" style="width: 200px;" /></p>
 
-		!!! tip "If the connection fails:"
-			* Connect to Reach hotspot again
-			* Check entered password
-			* Check that your network is configured correctly
-			* Try another Wi-Fi network
+	!!! tip "Se a conexão falhar:"
+		* Conecte-se ao ponto de acesso do Reach novamente
+		* Verifique a senha
+		* Verifique se a sua rede está configurada corretamente
+		* Tente outra rede Wi-Fi
 
 
-	## Go back to ReachView
+## Volte para o ReachView
 
-	??? note "Connecting to Reach with iOS/Android device"
-		
-		1. Connect your mobile device to the same Wi-Fi network as Reach
-		2. Scan for available Reach devices
-		3. Choose Reach from the list in the app
-
-
-	??? note "Connecting via a web browser from any device"
-
-		1. Connect your device to the same Wi-Fi network as Reach
-		2. Use [one of the Network Scan utility](https://docs.emlid.com/reachrs/quickstart/first-setup/#accessing-reach-rsrs-device-in-a-network) or ReachView app to determine the Reach IP address 
-		3. Go to IP address in a web browser
+??? note "Conectando-se ao Reach com dispositivos iOS/Android"
+	
+	1. Conecte seu dispositivo móvel à mesma rede Wi-Fi que o Reach
+	2. Verifique os dispositivos Reach desponíveis
+	3. Escolha o Reach na lista do aplicativo
 
 
-Once Reach connects to the Internet, you can:
+??? note "Conectando-se através de um navegador da web de qualquer dispositivo"
 
-* [Update the receiver](../reachview/settings/#check-app-version)
-* [Connect to NTRIP](../common/quickstart/ntrip-workflow/)
+	1. Conecte seu dispositivo móvel à mesma rede Wi-Fi que o Reach
+	2. Use um dos software de [Varredura de rede](https://docs.emlid.com/reachrs/quickstart/#acessando-o-reach-RSRS-em-uma-rede) ou use o aplicativo ReachView para encontrar o endereço de IP do Reach
+	3. Insira o endereço de IP em um navegador da web
+
+
+Depois que o Reach for conectado a uma rede Wi-Fi, você poderá:
+
+* [Atualizar o receptor](../reachview/settings/#check-app-version)
+* [Conectar a NTRIP](../common/quickstart/ntrip-workflow/)


### PR DESCRIPTION
Please, you need to update the link on Reach RS2 doc page. Actual link for this page (translated) goes to Reach RS+ page (https://doc.emlid.com.br/reachrs2/common/quickstart/connecting-to-the-internet/)