### PR TITLE
Change the name to Reach Module in docs

### DIFF
--- a/docs/reach/common/quickstart/connecting-to-the-internet.md
+++ b/docs/reach/common/quickstart/connecting-to-the-internet.md
@@ -1,11 +1,11 @@
-# Conectando o Reach à internet
+# Conectando o Reach Module à internet
 
-Conecte o Reach à internet para atualizar o ReachView para a versão mais recente ou para obter correções do seu serviço NTRIP.
+Conecte o Reach Module à internet para atualizar o ReachView para a versão mais recente ou para obter correções do seu serviço NTRIP.
 
 
 ## Conectando-se ao ReachView
 
-??? note "Conectando-se ao Reach com dispositivos iOS/Android"
+??? note "Conectando-se ao Reach Module com dispositivos iOS/Android"
 
 	1. Baixe o aplicativo no [Google Play](https://play.google.com/store/apps/details?id=com.reachview) ou [Apple Store](https://itunes.apple.com/us/app/reachview/id1295196887?mt=8)
 	2. Vá para as configurações de Wi-Fi no seu dispositivo
@@ -62,7 +62,7 @@ Conecte o Reach à internet para atualizar o ReachView para a versão mais recen
 
 <p style="text-align:center" ><img src="../img/quickstart/connecting-to-the-internet/new-connection.gif" style="width: 800px;" /></p>
 
-* Pressione o botão **"Connect"** (Conectar). O LED azul deve começar a piscar no Reach
+* Pressione o botão **"Connect"** (Conectar). O LED azul deve começar a piscar no Reach Module
 
 	<p style="text-align:center" ><img src="../img/quickstart/connecting-to-the-internet/network-scan.gif" style="width: 400px;" /></p>
 
@@ -81,7 +81,7 @@ Conecte o Reach à internet para atualizar o ReachView para a versão mais recen
 	* Ative o ponto de acesso Wi-Fi no seu dispositivo móvel
 	* Verifique se tem o mesmo nome e senha que você preencheu na etapa anterior
 	* Agora reinicie o dispositivo pressionando o botão **Power**
-	* O Reach deve se conectar ao seu ponto de acesso durante a próxima inicialização
+	* O Reach Module deve se conectar ao seu ponto de acesso durante a próxima inicialização
 
 
 * Se a conexão for bem sucedida, você verá o LED azul piscando lentamente
@@ -93,7 +93,7 @@ Conecte o Reach à internet para atualizar o ReachView para a versão mais recen
 	<p style="text-align:center" ><img src="../img/quickstart/connecting-to-the-internet/running-hotspot.png" style="width: 400px;" /></p>
 
 	!!! tip "Se a conexão falhar:"
-		* Conecte-se ao ponto de acesso do Reach novamente
+		* Conecte-se ao ponto de acesso do Reach Moduele novamente
 		* Verifique a senha
 		* Verifique se a sua rede está configurada corretamente
 		* Tente outra rede Wi-Fi
@@ -101,21 +101,21 @@ Conecte o Reach à internet para atualizar o ReachView para a versão mais recen
 
 ## Volte para o ReachView
 
-??? note "Conectando-se ao Reach com dispositivos iOS/Android"
+??? note "Conectando-se ao Reach Module com dispositivos iOS/Android"
 	
 	1. Conecte seu dispositivo móvel à mesma rede Wi-Fi que o Reach
-	2. Verifique os dispositivos Reach desponíveis
-	3. Escolha o Reach na lista do aplicativo
+	2. Verifique os dispositivos Reach Module desponíveis
+	3. Escolha o Reach Module na lista do aplicativo
 
 
 ??? note "Conectando-se através de um navegador da web de qualquer dispositivo"
 
-	1. Conecte seu dispositivo móvel à mesma rede Wi-Fi que o Reach
+	1. Conecte seu dispositivo móvel à mesma rede Wi-Fi que o Reach Module
 	2. Use um dos software de [Varredura de rede](https://docs.emlid.com/reachrs/quickstart/#acessando-o-reach-RSRS-em-uma-rede) ou use o aplicativo ReachView para encontrar o endereço de IP do Reach
 	3. Insira o endereço de IP em um navegador da web
 
 
-Depois que o Reach for conectado a uma rede Wi-Fi, você poderá:
+Depois que o Reach Module for conectado a uma rede Wi-Fi, você poderá:
 
 * [Atualizar o receptor](../../reachview/settings/#verifique-a-versao-do-aplicativo)
 * [Receber correções NTRIP](../../reachview/correction-input/#ntrip)

--- a/docs/reach/common/quickstart/downloading-files.md
+++ b/docs/reach/common/quickstart/downloading-files.md
@@ -1,13 +1,13 @@
-#Como baixar arquivos do Reach
+#Como baixar arquivos do Reach Module
 
-Este guia descreve como fazer o download do *"System report"* (Relatório do sistema), exportar projeto de levantamento ou salvar logs do Reach no seu PC, laptop, tablet ou smartphone.
+Este guia descreve como fazer o download do *"System report"* (Relatório do sistema), exportar projeto de levantamento ou salvar logs do Reach Module no seu PC, laptop, tablet ou smartphone.
 
 !!! note ""
 	É necessário conectar ao ReachView através do Wi-Fi para baixar os arquivos. Dados não podem ser transferidos via USB.
 
-##Ligando o Reach
+##Ligando o Reach Module
 
-Pressione o botão "Power" (Liga/Desliga) do Reach e espere ele ligar.
+Pressione o botão "Power" (Liga/Desliga) do Reach Module e espere ele ligar.
 
 ??? note "Guia Reach RS/RS+"
 
@@ -25,8 +25,8 @@ Pressione o botão "Power" (Liga/Desliga) do Reach e espere ele ligar.
 
 	Quando os LEDs de energia e o botão "Power" (Liga/Desliga) permanecerem sólidos, verifique o status do LED da rede.
 
-	* **O LED de rede é branco sólido.** O Reach está no modo hotspot e você pode conectar seu laptop ou smartphone. [Clique neste link para continuar seguindo o guia.] (#reach-esta-no-modo-hotspot)
-	* **O LED de rede está azul contínuo.** O Reach está no modo cliente e conectado à rede Wi-Fi. [Siga para esta parte do guia para continuar.] (#reach-esta-no-modo-cliente)
+	* **O LED de rede é branco sólido.** O Reach Module está no modo hotspot e você pode conectar seu laptop ou smartphone. [Clique neste link para continuar seguindo o guia.] (#reach-esta-no-modo-hotspot)
+	* **O LED de rede está azul contínuo.** O Reach Module está no modo cliente e conectado à rede Wi-Fi. [Siga para esta parte do guia para continuar.] (#reach-esta-no-modo-cliente)
 	<br>
 
 	|Modo hotspot|Modo cliente|
@@ -113,7 +113,7 @@ O download é concluído com sucesso. Para obter o arquivo, vá para a pasta ond
 
 ###Notebook ou Desktop
 
-Os arquivos do Reach geralmente são salvos por padrão na pasta **Downloads**.
+Os arquivos do Reach Module geralmente são salvos por padrão na pasta **Downloads**.
 
 ###Smartphone ou tablet
 

--- a/docs/reach/common/quickstart/ntrip-workflow.md
+++ b/docs/reach/common/quickstart/ntrip-workflow.md
@@ -5,23 +5,23 @@
 Este guia explica como configurar o Reach para receber mensagens de correção de um serviço NTRIP.
 
 !!! tip ""
-	A configuração da entrada de correção NTRIP pode ser feita em casa antes do levantamento. Nesse caso, você só precisa conectar o Reach à Internet em campo.
+	A configuração da entrada de correção NTRIP pode ser feita em casa antes do levantamento. Nesse caso, você só precisa conectar o Reach Module à Internet em campo.
 
 ##Atualize o Reach
 
-Se você acabou de receber seu Reach, precisará atualizá-lo para ter todos os recursos mais recentes. A instrução está no estojo de transporte do Reach.
+Se você acabou de receber seu Reach Module, precisará atualizá-lo para ter todos os recursos mais recentes. A instrução está no estojo de transporte do Reach Module.
 
 Você também pode ver o tutorual [primeira configuração](../../../quickstart/first-setup) e no [canal da Emlid no YouTube](https://www.youtube.com/watch?v=fIY__hNjcNI).
 
-##Conecte o Reach a Internet
+##Conecte o Reach Module a Internet
 
-O Reach requer conexão com a Internet para utilizar o NTRIP. Você não precisa de nenhum dispositivo ou software especial para isso, apenas um smartphone com um recurso de ponto de acesso (roteador).
+O Reach Module requer conexão com a Internet para utilizar o NTRIP. Você não precisa de nenhum dispositivo ou software especial para isso, apenas um smartphone com um recurso de ponto de acesso (roteador).
 
-Ative os dados móveis no seu smartphone e compartilhe-os através do ponto de acesso Wi-Fi. O Reach se conectará à sua rede e terá acesso à Internet.
+Ative os dados móveis no seu smartphone e compartilhe-os através do ponto de acesso Wi-Fi. O Reach Module se conectará à sua rede e terá acesso à Internet.
 
 [Consulte o tutorial para obter mais informações sobre como conectar o Reach a outras redes.](../../tutorials/connecting-to-the-internet/)
 
-##Configure o Reach para o modo RTK com NTRIP
+##Configure o Reach Module para o modo RTK com NTRIP
 
 Abra o ReachView e vá para **"RTK settings"**. Defina tudo para as mesmas opções da imagem abaixo.
 

--- a/docs/reach/common/reachview/base-mode.md
+++ b/docs/reach/common/reachview/base-mode.md
@@ -2,13 +2,13 @@
 
 <p style="text-align:center"><img src="../img/reachview/base_mode/output.png" style="width: 800px;"/></p>
 
-Reach envia correção em formato de RTCM3 padrão da indústria. Dados corrigidos podem ser enviados via Serial, TCP, NTRIP ou LoRa para Reach RS/RS+.
+Reach Module envia correção em formato de RTCM3 padrão da indústria. Dados corrigidos podem ser enviados via Serial, TCP, NTRIP ou LoRa para Reach RS/RS+.
 
 ### Serial
 Conexão de porta serial está disponível através de várias opções de conexão de hardware. Todos eles suportam as seguintes taxas de transmissão: 4800, 9600, 14400, 19200, 28800, 38400, 56000, 57600, 115200, 128000, 153600, 230400, 256000, 460800.
 
 #### UART
-Corresponde a UART TTL no módulo Reach ou a porta RS232 no conector extensível do Reach RS/RS+. Maneira comum para ligar o rádio ou outro dispositivo que ofereça a correção.
+Corresponde a UART TTL no módulo Reach Module ou a porta RS232 no conector extensível do Reach RS/RS+. Maneira comum para ligar o rádio ou outro dispositivo que ofereça a correção.
 
 #### USB-to-PC
 Quando conectado por USB a um PC Reach vai aparecer como vários dispositivos, um deles será uma porta serial. Você pode usar a porta serial para enviar correções para o PC.

--- a/docs/reach/common/reachview/camera-control.md
+++ b/docs/reach/common/reachview/camera-control.md
@@ -1,4 +1,4 @@
-Reach é capaz de disparar câmeras, bem como registrar eventos. Recurso de marcar um evento é indispensável para mapeamento aéreo, pois permite para registrar o tempo exato quando o obturador foi ativado.
+Reach Module é capaz de disparar câmeras, bem como registrar eventos. Recurso de marcar um evento é indispensável para mapeamento aéreo, pois permite para registrar o tempo exato quando o obturador foi ativado.
 
 <p style="text-align:center" ><img src="../img/reachview/camera_control/camera.png" style="width: 800px;" /></p>
 
@@ -10,7 +10,7 @@ Você vê o tempo do último registro para depuração em tempo real. Só funcio
 
 #### Conectando Reach M+ a uma câmera utilizando HSA
 
-Para conectar o Reach uma câmera com adaptador de sapata (HSA) use cabo de 5 pinos JST-GH. Certifique-se de que ligar o adaptador a uma sapata de uma câmera corretamente:
+Para conectar o Reach Module uma câmera com adaptador de sapata (HSA) use cabo de 5 pinos JST-GH. Certifique-se de que ligar o adaptador a uma sapata de uma câmera corretamente:
 
 <p style="text-align:center" ><img src="../img/reachview/camera_control/emlid-hotshoe.jpg" style="width: 500px;" /></p>
 

--- a/docs/reach/common/reachview/correction-input.md
+++ b/docs/reach/common/reachview/correction-input.md
@@ -1,6 +1,6 @@
 ## Correção da base
 
-Configuração da correção é necessária se você quiser ir além do posicionamento autônomo. Reach suporta os seguintes formatos de correção: RTCM2, RTCM3, OEM4, OEM3, UBX, SS2, HEMIS, SKYTRAQ, SP3. RTCM3 é o formato mais popular na indústria. Dados em qualquer um desses formatos podem ser recebidos via Serial, TCP, NTRIP, Bluetooth ou LoRa para Reach RS/RS+.
+Configuração da correção é necessária se você quiser ir além do posicionamento autônomo. Reach Module suporta os seguintes formatos de correção: RTCM2, RTCM3, OEM4, OEM3, UBX, SS2, HEMIS, SKYTRAQ, SP3. RTCM3 é o formato mais popular na indústria. Dados em qualquer um desses formatos podem ser recebidos via Serial, TCP, NTRIP, Bluetooth ou LoRa para Reach RS/RS+.
 
 ### Serial
 

--- a/docs/reach/common/reachview/firmware-reflashing.md
+++ b/docs/reach/common/reachview/firmware-reflashing.md
@@ -1,4 +1,4 @@
-Nestsa página, você encontrará as informações sobre como realizar o reflash de firmware do Reach.
+Nestsa página, você encontrará as informações sobre como realizar o reflash de firmware do Reach Module.
 
 Observe que você **não** precisa fazer isso, a menos que queira levar o Reach ao estado inicial.
 
@@ -41,7 +41,7 @@ Observe que você **não** precisa fazer isso, a menos que queira levar o Reach 
 
 	### Processo de flashing
 
-	* Abra o Reach Firmware Flash Tool e escolha o modelo de Reach
+	* Abra o Reach Firmware Flash Tool e escolha o modelo de Reach Module
 
 	<p style="text-align:center" ><img src="../img/reachview/firmware-reflashing/app-step1-device-select.png" style="width: 300px;" /></p>
 
@@ -51,11 +51,11 @@ Observe que você **não** precisa fazer isso, a menos que queira levar o Reach 
 
 	<p style="text-align:center" ><img src="../img/reachview/firmware-reflashing/app-step2-image-select.png" style="width: 300px;" /></p>
 
-	* Desconecte todas as unidades do Reach. Se não houver nenhuma, o Flash Tool pulará automaticamente esta etapa
+	* Desconecte todas as unidades do Reach Module. Se não houver nenhuma, o Flash Tool pulará automaticamente esta etapa
 	
 	<p style="text-align:center" ><img src="../img/reachview/firmware-reflashing/app-step3-disconnect-devices.png" style="width: 300px;" /></p>
 
-	* Conecte o dispositivo Reach e ligue-o. A mensagem "Reach conectado" será exibida
+	* Conecte o dispositivo Reach Module e ligue-o. A mensagem "Reach conectado" será exibida
 
 	<p style="text-align:center" ><img src="../img/reachview/firmware-reflashing/app-step4-connected-reach.png" style="width: 300px;" /></p>
 
@@ -66,11 +66,11 @@ Observe que você **não** precisa fazer isso, a menos que queira levar o Reach 
 	* Após o reflashing, o Reach será reinicializado
 
 	!!! danger ""
-		Não desconecte o Reach nesta etapa.
+		Não desconecte o Reach Module nesta etapa.
 
 	<p style="text-align:center" ><img src="../img/reachview/firmware-reflashing/app-step5-rebooting.png" style="width: 300px;" /></p>
 
-	* Quando o Reach for reinicializado com sucesso, você verá a mensagem "Reach is flashed and ready to use" e estará pronto para o uso.
+	* Quando o Reach Module for reinicializado com sucesso, você verá a mensagem "Reach is flashed and ready to use" e estará pronto para o uso.
 
 	<p style="text-align:center" ><img src="../img/reachview/firmware-reflashing/app-step5-flashed-reach.png" style="width: 300px;" /></p>
 
@@ -123,9 +123,9 @@ Observe que você **não** precisa fazer isso, a menos que queira levar o Reach 
 	* [Guia rápido para Reach RS+](https://docs.emlid.com/reachrs/quickstart/first-setup)
 	* [Guia rápido para Reach M+](https://docs.emlid.com/reachm-plus/quickstart/)
 
-??? note " Guia para o flash de firmware do Reach RS / RTK"
+??? note " Guia para o flash de firmware do Reach RS / Module"
 
-	### Download do firmware do Reach RS / RTK
+	### Download do firmware do Reach RS / Module
 
 	Obtenha a versão mais recente da imagem ReachView:
 
@@ -206,7 +206,7 @@ Observe que você **não** precisa fazer isso, a menos que queira levar o Reach 
 		Não desconecte-o até que ele seja reinicializado e passe completamente pelo processo de configuração inicial.
 
 
-	Continue na seção guia rápido para configurar o seu Reach RS / RTK:
+	Continue na seção guia rápido para configurar o seu Reach RS / Module:
 
 	* [Guia rápido para Reach RS](https://docs.emlid.com/reachrs/quickstart/first-setup)
-	* [Guia rápido para Reach RTK](https://docs.emlid.com/reach/quickstart/)
+	* [Guia rápido para Reach Module](https://docs.emlid.com/reach/quickstart/)

--- a/docs/reach/common/reachview/index.md
+++ b/docs/reach/common/reachview/index.md
@@ -8,7 +8,7 @@ O ReachView é um aplicativo baseado na web que permite que você assuma o contr
 
 O aplicativo ReachView é exibido por meio de um navegador ou de um aplicativo nativo para iOS/Android. Para acessar o dispositivo Reach, é necessário encontrar o endereço IP do Reach na rede. Dependendo do sistema operacional e da versão do aplicativo ReachView a bordo do Reach ou do Reach RS/RS +, isso pode ser feito de diferentes maneiras.
 
-??? note "A versão do Reach View mais antiga que v2.8.0"
+??? note "A versão do ReachView mais antiga que v2.8.0"
 
     ### Quando o Reach está conectado ao Wi-Fi
 

--- a/docs/reach/rtk/antenna-placement.md
+++ b/docs/reach/rtk/antenna-placement.md
@@ -1,5 +1,5 @@
 !!! tip ""
-O Reach foi substituído por [Reach M+](https://emlid.com/reach). A documentação para o Reach M+ pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
+	O Reach Module foi substituído por [Reach M+](https://emlid.com/reach). A documentação para o Reach M+ pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
 
 ### Uma antena bem posicionada é crucial para alcançar bons resultados de posicionamento RTK
 

--- a/docs/reach/rtk/ardupilot-integration.md
+++ b/docs/reach/rtk/ardupilot-integration.md
@@ -1,5 +1,5 @@
 !!! tip ""
-	Reach foi substituído por [Reach M+](https://emlid.com/reach). A documentação para o Reach M + pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
+	Reach Module foi substituído por [Reach M+](https://emlid.com/reach). A documentação para o Reach M + pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
 
 Como o ReachView versão **0.3.0** o Reach oferece suporte à saída de coordenadas aprimoradas por RTK para os pilotos automáticos Navio e Pixhawk. Para tornar isso possível, implementamos um protocolo personalizado que chamamos de **ERB**(Emlid Reach Binary protocol).
 
@@ -26,12 +26,12 @@ A configuração que recomendamos é a seguinte:
 
 *	Navio ou Pixhawk com o firmware do ArduPilot (não menos que a versão 3.4.0 para ArduCopter, 3.6.0 para ArduPlane e 3.0.1 para ArduRover). É preferível usar a última versão estável
 * Estações base é uma unidade Reach RS/RS+ no modo Wi-Fi AP, configurada como um servidor TCP
-* O GCS é um laptop com o Mission Planner (versão 1.3.35 e superior), conectado à rede Wi-Fi do Reach.
+* O GCS é um laptop com o Mission Planner (versão 1.3.35 e superior), conectado à rede Wi-Fi do Reach Module.
 * Conexão de telemetria através de um rádio serial
 * A unidade Rover Reach M + é montada em um drone e conectada ao Navio ou ao Pixhawk através do fio 6P-to-6P. Esse tipo de conexão resolverá três problemas de uma vez: power Reach, permite que a placa ArduPilot passe por correções de base e permita que Reach passe a solução RTK de volta.
 
 
-O guia a seguir mostrará como configurar o Navio ou o Pixhawk e o Reach para funcionar nessa configuração. Se você deseja alterar este fluxo de trabalho, deve ser bastante fácil fazê-lo, já que todas as partes do sistema são independentes das outras.
+O guia a seguir mostrará como configurar o Navio ou o Pixhawk e o Reach Module para funcionar nessa configuração. Se você deseja alterar este fluxo de trabalho, deve ser bastante fácil fazê-lo, já que todas as partes do sistema são independentes das outras.
 
 
 

--- a/docs/reach/rtk/hardware-integration.md
+++ b/docs/reach/rtk/hardware-integration.md
@@ -1,21 +1,21 @@
 !!! tip ""
-	Reach foi substituído por [Reach M+](https://emlid.com/reach). A documentação para o Reach M + pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
+	Reach Module foi substituído por [Reach M+](https://emlid.com/reach). A documentação para o Reach M + pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
 
-O Reach suporta vários acessórios através da porta USB OTG incorporada e interface UART no conector DF13.
+O Reach Module suporta vários acessórios através da porta USB OTG incorporada e interface UART no conector DF13.
 
 ### Rádio
 
-É possível conectar módulos de rádio do Reach a fim de obter correções ou enviar coordenadas calculadas.
+É possível conectar módulos de rádio do Reach Module a fim de obter correções ou enviar coordenadas calculadas.
 
 A maioria das rádios hoje em dia usam UART ou USB como conexão.
 
 #### Conectando radio UART
 
-Nível de carga da porta UART no Reach é 3.3V mas os pinos suportam até 5V, então você pode usar rádios de 3.3V e 5V.
+Nível de carga da porta UART no Reach Module é 3.3V mas os pinos suportam até 5V, então você pode usar rádios de 3.3V e 5V.
 
-Rádio UART é acessível no Reach como um dispositivo serial com o nome de **ttyMFD2**.
+Rádio UART é acessível no Reach Module como um dispositivo serial com o nome de **ttyMFD2**.
 
-Para se conectar a rádio UART ao Reach use a porta JST-GH (S1).
+Para se conectar a rádio UART ao Reach Module use a porta JST-GH (S1).
 
 | Pinos do Reach | Pinos do Rádio |
 |:--------------:|:--------------:|
@@ -34,7 +34,7 @@ Diagrama de conexão para 3DR Radio v2:
 
 Rádio 3DR também pode ser conectado via USB.
 
-Observe que um bug na imagem do **Reach antes da v1.2** impede o módulo Rover de inicializar enquanto está `recebendo sinais de correção UART do módulo base. A correção atual está energizando o módulo base após inicializar o rover (o LED está piscando em vermelho/azul/branco).
+Observe que um bug na imagem do **Reach Module antes da v1.2** impede o módulo Rover de inicializar enquanto está `recebendo sinais de correção UART do módulo base. A correção atual está energizando o módulo base após inicializar o rover (o LED está piscando em vermelho/azul/branco).
 
 #### Rádio RFD900
 
@@ -51,6 +51,6 @@ Diagrama de conexão para o rádio RFD900:
 
 <div style="text-align: center;"><img src="../img/reach/hardware-integration/reach-usb-radio.png" style="width: 550px;"></div><br>
 
-Para conectar o rádio USB ao Reach, use o cabo USB-OTG fornecido com o pacote. 
-Conecte o rádio na porta USB-F e conecte a extremidade Micro-USB do cabo no Reach.
-**Ao usar a porta USB no modo OTG, o Reach tem que ser [energizado](power-supply.md) sobre uma das portas DF13 ports**.
+Para conectar o rádio USB ao Reach Module, use o cabo USB-OTG fornecido com o pacote. 
+Conecte o rádio na porta USB-F e conecte a extremidade Micro-USB do cabo no Reach Module.
+**Ao usar a porta USB no modo OTG, o Reach Module tem que ser [energizado](power-supply.md) sobre uma das portas DF13 ports**.

--- a/docs/reach/rtk/index.md
+++ b/docs/reach/rtk/index.md
@@ -1,13 +1,13 @@
 !!! tip ""
-	O Reach foi substituído por [Reach M+](https://emlid.com/reach). A documentação para o Reach M+ pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
+	O Reach Module foi substituído por [Reach M+](https://emlid.com/reach). A documentação para o Reach M+ pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
 
 <div style="text-align: center;"><img src="img/reach/Reach_400x400-400x380.png" style="width: 350px;"></div><br>
 
-### Kit Reach RTK
+### Kit Reach Module
 
-O Kit Reach RTK inclui o seguinte:
+O Kit Reach Module inclui o seguinte:
 
-* 2x módulo Reach RTK
+* 2x módulo Reach Module
 
 * 2x antena Tallysman TW4721 com montagem adesiva
 
@@ -19,11 +19,11 @@ O Kit Reach RTK inclui o seguinte:
 
 * 2x Micro-USB <-> Cabo USB-F OTG
 
-### Apenas a unidade Reach 
+### Apenas a unidade Reach Module 
 
 Apenas a unidade Reach vêm com o seguinte:
 
-* módulo Reach RTK
+* módulo Reach Module
 
 * DF13 <-> DF13 straight cable
 

--- a/docs/reach/rtk/led-status.md
+++ b/docs/reach/rtk/led-status.md
@@ -1,14 +1,14 @@
 !!! tip ""
-	O Reach foi substituído por [Reach M+](https://emlid.com/reach). A documentação do Reach M+ pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
+	O Reach Module foi substituído por [Reach M+](https://emlid.com/reach). A documentação do Reach M+ pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
 
 
 !!! note ""
     Funcionalidade de LED está disponível com o ReachView versão 2.7.0 e mais recente 
 
 
-## Sequência do LED de inicialização do Reach
+## Sequência do LED de inicialização do Reach Module
 
-O LED do Reach é um LED RGB que percorre um padrão simples:
+O LED do Reach Module é um LED RGB que percorre um padrão simples:
 
 Estado da rede -> estado do aplicativo
 
@@ -20,7 +20,7 @@ Durante o boot, o Reach passará por três etapas:
 
 ### Varredura de rede
 
-Durante a inicialização, o Reach entre em um estado de varredura de rede no qual ele tentará se conectar a qualquer rede Wi-Fi conhecida que possa encontrar. Isso pode resultar no conexão a uma rede adicionada anteriormente ou no criação de seu próprio ponto de acesso.
+Durante a inicialização, o Reach Module entre em um estado de varredura de rede no qual ele tentará se conectar a qualquer rede Wi-Fi conhecida que possa encontrar. Isso pode resultar no conexão a uma rede adicionada anteriormente ou no criação de seu próprio ponto de acesso.
 
 | Descrição | Demo |
 |-----------|------|
@@ -52,7 +52,7 @@ Após a sincronização de tempo, o **piscar magenta** parará e o ReachView ser
 A tabela abaixo demonstra possíveis padrões de flash descrevendo vários status do recptor.  
 
 
-| Statu do Reach | Sincronização de tempo   -> | Rede   -> | Status do aplicativo | Demo |
+| Statu do Reach Module| Sincronização de tempo    | Rede    | Status do aplicativo | Demo |
 |--------------|-----------|---------------------|---------|-----------|
 |<br> <div style="text-align: center;">    Desligado   </div>                   | <br>  </div>    |  <br> </div> | <br> </div>|<br>  <div style="text-align: center;"><img src="../img/reach/led-status/off.png" style="width: 150px;"></div>   |
 |<br> <div style="text-align: center;">    Falta de energia   </div>                   | <br>  <div style="text-align: center;"><img src="../img/reach/led-status/magenta.png" style="height: 30px;"><br>Pisca a cada 10-15 seg</div>    |  <br> </div> | <br> </div>|<br>  <div style="text-align: center;"><img src="../img/reach/led-status/low-power.gif" style="width: 150px;"></div>   |

--- a/docs/reach/rtk/power-supply.md
+++ b/docs/reach/rtk/power-supply.md
@@ -1,9 +1,9 @@
 !!! tip ""
-O Reach foi substituiído por [Reach M+](https://emlid.com/reach). A documentação para o Reach M+ pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
+	O Reach Module foi substituiído por [Reach M+](https://emlid.com/reach). A documentação para o Reach M+ pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
 
-## Como carregar o Reach RTK
+## Como carregar o Reach Module
 
-O módulo RTK Reach da Emlid pode ser carregado usando as portas **Micro-USB** ou **DF13**. O circuito de energia é compartilhado para todas as portas, portanto, quando você liga o dispositivo em uma porta, ele passa energia para outras portas.
+O módulo Reach da Emlid pode ser carregado usando as portas **Micro-USB** ou **DF13**. O circuito de energia é compartilhado para todas as portas, portanto, quando você liga o dispositivo em uma porta, ele passa energia para outras portas.
 
 !!! danger "Atenão"
 Não conecte duas fonte de energia ao mesmo tempo, isso pode danificar o dispositivo.
@@ -14,7 +14,7 @@ Não conecte duas fonte de energia ao mesmo tempo, isso pode danificar o disposi
 
 <div style="text-align: center;"><img src="../img/reach/power-supply/usb-power-supply.png" style="width: 550px;"></div><br>
 
-Você pode carregar o Reach por um cabo Micro-USB usando fontes de energia como:
+Você pode carregar o Reach Module por um cabo Micro-USB usando fontes de energia como:
 
 * Power bank
 * Adaptador de tomada USB
@@ -24,10 +24,10 @@ Você pode carregar o Reach por um cabo Micro-USB usando fontes de energia como:
 
 ### Carregando usando portas DF13
 
-O Reach pode ser ativado fornecendo 5Volts aos pinos correspondentes em qualquer umas das duas portas DF13.
+O Reach Module pode ser ativado fornecendo 5Volts aos pinos correspondentes em qualquer umas das duas portas DF13.
 
 <div style="text-align: center;"><img src="../img/reach/power-supply/df13-power-supply.png" style="width: 550px;"></div><br>
 
-Quando o Reach é carregado pela porta DF13, ele passa energia para dispositivos conectados à porta Micro-USB OTG, como pen drives, modems 3G\4G, rádios USB, etc.
+Quando o Reach Module é carregado pela porta DF13, ele passa energia para dispositivos conectados à porta Micro-USB OTG, como pen drives, modems 3G\4G, rádios USB, etc.
 
 <div style="text-align: center;"><img src="../img/reach/power-supply/accessory-power-supply.png" style="width: 550px;"></div><br>

--- a/docs/reach/rtk/quickstart.md
+++ b/docs/reach/rtk/quickstart.md
@@ -1,9 +1,9 @@
 !!! tip ""
-	O Reach foi substituído por [Reach M+](https://emlid.com/reach). A documentação para o Reach M+ pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
+	O Reach Module foi substituído por [Reach M+](https://emlid.com/reach). A documentação para o Reach M+ pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
 
 ## Introdução
 
-Neste guia rápido, mostraremos como configurar dois dispositivos Reach, um como base e um como rover com link de correção via Wi-Fi.
+Neste guia rápido, mostraremos como configurar dois dispositivos Reach Module, um como base e um como rover com link de correção via Wi-Fi.
 
 !!! tip ""
     Se você encontrar algum problema ao executar essas etapas, ficaremos felizes em ajudar no nosso [**fórum da comunidade**](http://community.emlid.com/).
@@ -20,7 +20,7 @@ Este tutorial cobre apenas um caso de uso. Para obter mais informações, siga e
 
 * Pegue o **Micro-USB <--> cabo USB** que vem com o pacote.
 
-* Ligue a extremidade **Micro-USB** do cabo à porta **Micro-USB** no Reach e ligue a outra extremidade a uma fonte de energia de 5V, como um power bank, um adpatador de tomada USB ou uma porta USB de um computador.
+* Ligue a extremidade **Micro-USB** do cabo à porta **Micro-USB** no Reach Module e ligue a outra extremidade a uma fonte de energia de 5V, como um power bank, um adpatador de tomada USB ou uma porta USB de um computador.
 
 !!! danger "Atenção"
     Não conecte duas fontes de energia ao mesmo tempo, pois isso pode danificar o dispositivo.
@@ -29,7 +29,7 @@ Mais sobre a fonte de energia você pode ler [aqui](power-supply.md).
 
 ## Conectando e colocando a antena GPS
 
-* Conecte o cabo da antena a entrada MCX no Reach. 
+* Conecte o cabo da antena a entrada MCX no Reach Module. 
 
 * Coloque a antena em um plano de apoio. Pode ser uma chapa de metal > 100 mm de diâmetro, o teto de uma carro ou o teto de metal de um edifício. 
 
@@ -39,9 +39,9 @@ Mais sobre a fonte de energia você pode ler [aqui](power-supply.md).
 
 Um guia sobre posicionar corretamente as antenas está disponível na seçãoA guide how to properly place the antennas is available in [Posicionamento da antena](antenna-placement.md) section.
 
-## Conectando-se ao Reach
+## Conectando-se ao Reach Module
 
-Quando o Reach é ligado pela primeira vez, ele cria um ponto de acesso Wi-Fi.
+Quando o Reach Module é ligado pela primeira vez, ele cria um ponto de acesso Wi-Fi.
 
 * Abra a lista de redes Wi-Fi no seu smartphone, tablet ou laptop.
 
@@ -51,14 +51,14 @@ Quando o Reach é ligado pela primeira vez, ele cria um ponto de acesso Wi-Fi.
 
 ## Configurando o Wi-Fi
 
-Depois de se conectar à rede hospedada pelo Reach, abra um navegador da web em seu smartphone, tablet ou laptop.
+Depois de se conectar à rede hospedada pelo Reach Module, abra um navegador da web em seu smartphone, tablet ou laptop.
 
 * Digite **http://reach.local** ou **http://192.168.42.1** na barra de endereços e você verá a tela de atualização do ReachView.
 
 <div style="text-align: center;"><img src="../img/reach/quickstart/reach_view_updater_main.png" style="width: 700px;"></div><br>
 
 !!! note ""
-    Se sua inteface parecer diferente, você precisará realizar o reflash no dispositivo Reach com a imagem v2.3 seguindo [este guia](common/reachview/firmware-reflashing.md). Só precisa de o fazer se o seu dispositivo tiver sido comprado antes de 1 de março de 2017.
+    Se sua inteface parecer diferente, você precisará realizar o reflash no dispositivo Reach Module com a imagem v2.3 seguindo [este guia](common/reachview/firmware-reflashing.md). Só precisa de o fazer se o seu dispositivo tiver sido comprado antes de 1 de março de 2017.
 
 * Pressione o botão Mais e insira o nome da rede Wi-Fi, o tipo de segurança e a senha. Pressione o botão Salvar.
 
@@ -116,7 +116,7 @@ Depois de iniciar o aplicativo, você verá a lista dos receptores disponíveis 
 
 ## Atualizando o ReachView
 
-Após conectar-se ao Reach, você verá novamente a tela de atualização do ReachView, que instalará as atualizações mais recentes.
+Após conectar-se ao Reach Module, você verá novamente a tela de atualização do ReachView, que instalará as atualizações mais recentes.
 
 <div style="text-align: center;"><img src="../img/reach/quickstart/reach_view_updater_finish.png" style="width: 700px;"></div><br>
 
@@ -144,7 +144,7 @@ O menu do ReachView consiste em 9 guias, mas só precisamos de três para começ
 
 ### Configurando a estação base
 
-* Conecte-se ao Reach que você deseja usar como base.
+* Conecte-se ao Reach Module que você deseja usar como base.
 
 * Navegue até a guia **Base mode** e ative a opção Correction output.
 
@@ -157,7 +157,7 @@ Por padrão, a saída de correção da base estará disponível em uma porta **T
 
 ### Configurando o Rover
 
-* Conecte-se ao segundo Reach. 
+* Conecte-se ao segundo Reach Module. 
 
 * Navegue até a guia **Correction input**. 
 

--- a/docs/reach/rtk/specs.md
+++ b/docs/reach/rtk/specs.md
@@ -1,19 +1,19 @@
 !!! tip ""
-	O Reach foi substituído por [Reach M+](https://emlid.com/reach). A documentação do Reach M+ pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
+	O Reach Module foi substituído por [Reach M+](https://emlid.com/reach). A documentação do Reach M+ pode ser encontrada [aqui](https://docs.emlid.com/reachm-plus/).
 
 ## Especificações mecânicas
 
 ### Dimensões
 
-O módulo Reach RTK é um pequeno dispositivo, é apenas alguns milímetros maior do que o Intel Edinson que ele hospeda.
+O módulo Reach Module é um pequeno dispositivo, é apenas alguns milímetros maior do que o Intel Edinson que ele hospeda.
 
 <div style="text-align: center;"><img src="../img/reach/specs/reach-dimensions.png" style="width: 350px;"></div><br>
 
 ### Partes dos conectores
 
-O Reach tem dois conectores DF13 e vem com todos os cabos necessários para se conectar a outros dispositivos. Caso você queira fazer sua própria montagem de cabos, aqui estão os números de peça de conectores apropriados:
+O Reach Module tem dois conectores DF13 e vem com todos os cabos necessários para se conectar a outros dispositivos. Caso você queira fazer sua própria montagem de cabos, aqui estão os números de peça de conectores apropriados:
 
-* No Reach: Hirose DF13-6P-1.25H(50) ([Digikey](http://www.digikey.com/product-detail/en/DF13-6P-1.25H%2850%29/H3354-ND/530653), [Mouser](http://eu.mouser.com/ProductDetail/Hirose-Electric/DF13-6P-125H50/?qs=%2fha2pyFaduilOJdMONLaLBwaFNH0V7VnzXasUV9hMRidfNFMCnSnIA%3d%3d)).
+* No Reach Module: Hirose DF13-6P-1.25H(50) ([Digikey](http://www.digikey.com/product-detail/en/DF13-6P-1.25H%2850%29/H3354-ND/530653), [Mouser](http://eu.mouser.com/ProductDetail/Hirose-Electric/DF13-6P-125H50/?qs=%2fha2pyFaduilOJdMONLaLBwaFNH0V7VnzXasUV9hMRidfNFMCnSnIA%3d%3d)).
 
 * Receptáculo: Hirose DF13-6S-1.25C ([Digikey](http://www.digikey.com/product-search/en?keywords=DF13-6S-1.25C), [Mouser](http://eu.mouser.com/ProductDetail/Hirose-Electric/DF13-6S-125C/?qs=%2fha2pyFaduhJ5h7X7LLPzEL0u%2f%252b1ZTztM8mMa9tEuYmcKFXQSgLZyQ%3d%3d))
 
@@ -23,7 +23,7 @@ O Conector de antena é MCX, para conectar ao cabo de antena SMA ou TNC você po
 
 ### Modelo 3D
 
-Este modelo 3D pode ser usado como referência para o designe. Por favor, note que o Reach vem em proteção térmica que aumenta um pouco suas dimensões externas.
+Este modelo 3D pode ser usado como referência para o designe. Por favor, note que o Reach Module vem em proteção térmica que aumenta um pouco suas dimensões externas.
 
 <script src="https://embed.github.com/view/3d/emlid/hardware/master/Reach.STL"></script>
 
@@ -36,19 +36,19 @@ Durante o projeto do case, lembre-se de que você não deve colocar nada próxim
 
 Os seguintes cases 3D imprimíveis estão disponíveis para usuários do Reach:
 
-**Reach case modelo C:**
+**Reach Module case modelo C:**
 
 <script src="https://embed.github.com/view/3d/emlid/hardware/master/Reach_cases/Reach_case_assembly_Rev_C.STL"></script>
 
 Download da [metade superior e inferior](https://github.com/emlid/hardware/tree/master/Reach_cases/Rev_C_parts) do case para imprimi-lo.
 
-**Reach case modelo D:**
+**Reach Module case modelo D:**
 
 <script src="https://embed.github.com/view/3d/emlid/hardware/master/Reach_cases/Reach_case_assembly_Rev_D.STL"></script>
 
 Download da [metade superior e inferior](https://github.com/emlid/hardware/tree/master/Reach_cases/Rev_D_parts) do case para imprimi-lo.
 
-**Reach case modelo E:**
+**Reach Module case modelo E:**
 
 <script src="https://embed.github.com/view/3d/emlid/hardware/master/Reach_cases/Reach_case_assembly_Rev_E.STL"></script>
 
@@ -87,4 +87,4 @@ Oficialmente, a Intel Edinson está classificada entre 0°C e 40°C, mas a Intel
 
 <div style="text-align: center;"><img src="../img/reach/specs/otg-connection.png" style="width: 550px;"></div><br>
 
-O Reach pode receber energia do USB, atuando como um dispositivo e fonte de energia para a porta que atua como um host. Para usar o Reach no modo OTG, você precisará conectar a fonte de energia de 5V aos pinos do conector DF13 (5V, GND) e usar o cabo USB do OTG.
+O Reach Module pode receber energia do USB, atuando como um dispositivo e fonte de energia para a porta que atua como um host. Para usar o Reach Module no modo OTG, você precisará conectar a fonte de energia de 5V aos pinos do conector DF13 (5V, GND) e usar o cabo USB do OTG.

--- a/reach.yml
+++ b/reach.yml
@@ -1,4 +1,4 @@
-site_name: Reach RTK docs
+site_name: Reach Module docs
 site_url: https://emlid.com.br/reach/
 docs_dir: docs/reach/rtk
 copyright: "Emlid.com"


### PR DESCRIPTION
Change name to Reach Module in following files:
docs: reach: common: quickstart: connecting-to-the-internet.md
docs: reach: common: quickstart: downloading-files.md
docs: reach: common: quickstart: ntrip-workflow.md
docs: reach: common: reachview: base-mode.md
docs: reach: common: reachview: camera-control.md
docs: reach: common: reachview: correction-input.md
docs: reach: common: reachview: firmware-reflashing.md
docs: reach: common: reachview: index.md
docs: reach: rtk: antenna-placement.md
docs: reach: rtk: ardupilot-integration.md
docs: reach: rtk: hardware-integration.md
docs: reach: rtk: index.md
docs: reach: rtk: led-status.md
docs: reach: rtk: power-supply.md
docs: reach: rtk: quickstart.md
docs: reach: rtk: specs.md
modified: reach.yml